### PR TITLE
feat: in-app log viewer (F12) + library sort by title/artist/album

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "nightingale"
-version = "0.1.0"
+version = "0.3.3"
 dependencies = [
  "bevy",
  "bevy_embedded_assets",

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct AppConfig {
     pub last_video_flavor: Option<usize>,
     pub separator: Option<String>,
     pub language_overrides: Option<HashMap<String, String>>,
+    pub show_logs: Option<bool>,
 }
 
 impl AppConfig {
@@ -83,6 +84,10 @@ impl AppConfig {
         self.language_overrides
             .as_ref()
             .and_then(|m| m.get(hash).map(|s| s.as_str()))
+    }
+
+    pub fn show_logs(&self) -> bool {
+        self.show_logs.unwrap_or(false)
     }
 
     pub fn set_language_override(&mut self, hash: String, lang: String) {

--- a/src/log_viewer.rs
+++ b/src/log_viewer.rs
@@ -1,0 +1,395 @@
+use std::collections::VecDeque;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use bevy::prelude::*;
+
+use crate::ui::UiTheme;
+
+const MAX_LINES: usize = 500;
+const POLL_INTERVAL_SECS: f64 = 0.5;
+const OVERLAY_HEIGHT_PCT: f32 = 35.0;
+const DISPLAY_LINES: usize = 60;
+const LOG_FONT_SIZE: f32 = 11.0;
+
+pub struct LogViewerPlugin;
+
+impl Plugin for LogViewerPlugin {
+    fn build(&self, app: &mut App) {
+        let shared_lines = Arc::new(Mutex::new(VecDeque::<String>::new()));
+        let tailer = LogTailer::spawn(log_file_path(), Arc::clone(&shared_lines));
+
+        app.insert_resource(LogViewerState {
+            visible: false,
+            lines: VecDeque::new(),
+            shared_lines,
+            _tailer: tailer,
+            dirty: true,
+        })
+        .add_systems(Update, (toggle_log_viewer, sync_log_lines, render_log_overlay));
+    }
+}
+
+fn log_file_path() -> PathBuf {
+    dirs::home_dir()
+        .expect("could not find home directory")
+        .join(".nightingale")
+        .join("nightingale.log")
+}
+
+// --- Resources ---
+
+#[derive(Resource)]
+pub struct LogViewerState {
+    pub visible: bool,
+    lines: VecDeque<String>,
+    shared_lines: Arc<Mutex<VecDeque<String>>>,
+    _tailer: LogTailer,
+    dirty: bool,
+}
+
+/// Handle to the background tailer thread (kept alive via the resource).
+struct LogTailer {
+    _handle: std::thread::JoinHandle<()>,
+}
+
+impl LogTailer {
+    fn spawn(path: PathBuf, shared: Arc<Mutex<VecDeque<String>>>) -> Self {
+        let handle = std::thread::spawn(move || {
+            Self::run(path, shared);
+        });
+        Self { _handle: handle }
+    }
+
+    fn run(path: PathBuf, shared: Arc<Mutex<VecDeque<String>>>) {
+        let mut file_pos: u64 = 0;
+
+        // Read existing content first
+        if let Ok(mut file) = std::fs::File::open(&path) {
+            let mut buf = String::new();
+            if file.read_to_string(&mut buf).is_ok() {
+                let mut guard = shared.lock().unwrap();
+                for line in buf.lines() {
+                    if guard.len() >= MAX_LINES {
+                        guard.pop_front();
+                    }
+                    guard.push_back(line.to_string());
+                }
+                file_pos = buf.len() as u64;
+            }
+        }
+
+        loop {
+            std::thread::sleep(std::time::Duration::from_millis(
+                (POLL_INTERVAL_SECS * 1000.0) as u64,
+            ));
+
+            let Ok(mut file) = std::fs::File::open(&path) else {
+                continue;
+            };
+
+            let meta_len = file.metadata().map(|m| m.len()).unwrap_or(0);
+
+            // File was truncated / rotated
+            if meta_len < file_pos {
+                file_pos = 0;
+            }
+
+            if meta_len == file_pos {
+                continue;
+            }
+
+            if file.seek(SeekFrom::Start(file_pos)).is_err() {
+                continue;
+            }
+
+            let mut buf = String::new();
+            let Ok(bytes_read) = file.read_to_string(&mut buf) else {
+                continue;
+            };
+            file_pos += bytes_read as u64;
+
+            if !buf.is_empty() {
+                let mut guard = shared.lock().unwrap();
+                for line in buf.lines() {
+                    if guard.len() >= MAX_LINES {
+                        guard.pop_front();
+                    }
+                    guard.push_back(line.to_string());
+                }
+            }
+        }
+    }
+}
+
+// --- ANSI color parsing ---
+
+#[derive(Clone)]
+struct AnsiSpan {
+    text: String,
+    color: Color,
+}
+
+/// Default log text color (light gray)
+const DEFAULT_COLOR: Color = Color::srgb(0.78, 0.78, 0.82);
+
+fn ansi_code_to_color(code: u8) -> Color {
+    match code {
+        30 => Color::srgb(0.20, 0.20, 0.20), // black
+        31 => Color::srgb(0.90, 0.30, 0.30), // red
+        32 => Color::srgb(0.35, 0.85, 0.35), // green
+        33 => Color::srgb(0.90, 0.85, 0.30), // yellow
+        34 => Color::srgb(0.40, 0.55, 1.00), // blue
+        35 => Color::srgb(0.80, 0.45, 0.90), // magenta
+        36 => Color::srgb(0.40, 0.85, 0.85), // cyan
+        37 => Color::srgb(0.85, 0.85, 0.85), // white
+        // bright variants
+        90 => Color::srgb(0.50, 0.50, 0.50), // bright black (gray)
+        91 => Color::srgb(1.00, 0.45, 0.45), // bright red
+        92 => Color::srgb(0.50, 1.00, 0.50), // bright green
+        93 => Color::srgb(1.00, 1.00, 0.50), // bright yellow
+        94 => Color::srgb(0.55, 0.70, 1.00), // bright blue
+        95 => Color::srgb(1.00, 0.60, 1.00), // bright magenta
+        96 => Color::srgb(0.55, 1.00, 1.00), // bright cyan
+        97 => Color::srgb(1.00, 1.00, 1.00), // bright white
+        _  => DEFAULT_COLOR,
+    }
+}
+
+fn parse_ansi_line(line: &str) -> Vec<AnsiSpan> {
+    let mut spans = Vec::new();
+    let mut current_color = DEFAULT_COLOR;
+    let mut buf = String::new();
+    let mut chars = line.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' {
+            // Look for CSI sequence: ESC [ ... m
+            if chars.peek() == Some(&'[') {
+                chars.next(); // consume '['
+                let mut seq = String::new();
+                loop {
+                    match chars.next() {
+                        Some(c) if c.is_ascii_digit() || c == ';' => seq.push(c),
+                        Some('m') => break,
+                        _ => {
+                            // Not a valid SGR sequence, emit what we consumed
+                            buf.push('\x1b');
+                            buf.push('[');
+                            buf.push_str(&seq);
+                            break;
+                        }
+                    }
+                }
+                // Flush current buffer
+                if !buf.is_empty() {
+                    spans.push(AnsiSpan { text: buf.clone(), color: current_color });
+                    buf.clear();
+                }
+                // Parse SGR codes
+                if seq.is_empty() || seq == "0" {
+                    current_color = DEFAULT_COLOR;
+                } else {
+                    for part in seq.split(';') {
+                        if let Ok(code) = part.parse::<u8>() {
+                            if code == 0 {
+                                current_color = DEFAULT_COLOR;
+                            } else if (30..=37).contains(&code) || (90..=97).contains(&code) {
+                                current_color = ansi_code_to_color(code);
+                            }
+                            // Skip bold/underline/etc (1, 2, 3, 4...) — just ignore
+                        }
+                    }
+                }
+            } else {
+                buf.push(ch);
+            }
+        } else {
+            buf.push(ch);
+        }
+    }
+
+    if !buf.is_empty() {
+        spans.push(AnsiSpan { text: buf, color: current_color });
+    }
+
+    if spans.is_empty() {
+        spans.push(AnsiSpan { text: String::new(), color: DEFAULT_COLOR });
+    }
+
+    spans
+}
+
+// --- Components ---
+
+#[derive(Component)]
+struct LogOverlayRoot;
+
+#[derive(Component)]
+struct LogOverlayText;
+
+// --- Systems ---
+
+fn toggle_log_viewer(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut state: ResMut<LogViewerState>,
+    mut config: ResMut<crate::config::AppConfig>,
+) {
+    if keyboard.just_pressed(KeyCode::F12) {
+        state.visible = !state.visible;
+        state.dirty = true;
+        // Sync config so settings toggle stays in sync
+        config.show_logs = Some(state.visible);
+        config.save();
+    }
+}
+
+fn sync_log_lines(
+    mut state: ResMut<LogViewerState>,
+    config: Res<crate::config::AppConfig>,
+) {
+    // Sync visibility with settings toggle
+    let config_visible = config.show_logs();
+    if config_visible != state.visible {
+        state.visible = config_visible;
+        state.dirty = true;
+    }
+    if !state.visible {
+        return;
+    }
+    let shared = Arc::clone(&state.shared_lines);
+    let guard = shared.lock().unwrap();
+    if guard.len() != state.lines.len() || guard.back() != state.lines.back() {
+        state.lines = guard.clone();
+        state.dirty = true;
+    }
+}
+
+fn render_log_overlay(
+    mut commands: Commands,
+    mut state: ResMut<LogViewerState>,
+    theme: Res<UiTheme>,
+    existing: Query<Entity, With<LogOverlayRoot>>,
+) {
+    if !state.dirty {
+        return;
+    }
+    state.dirty = false;
+
+    // Always despawn old overlay
+    for entity in &existing {
+        commands.entity(entity).despawn();
+    }
+
+    if !state.visible {
+        return;
+    }
+
+    // Collect display lines with ANSI parsing
+    let display: Vec<Vec<AnsiSpan>> = state
+        .lines
+        .iter()
+        .rev()
+        .take(DISPLAY_LINES)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .map(|line| parse_ansi_line(line))
+        .collect();
+
+    commands
+        .spawn((
+            LogOverlayRoot,
+            Node {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(0.0),
+                left: Val::Px(0.0),
+                width: Val::Percent(100.0),
+                height: Val::Percent(OVERLAY_HEIGHT_PCT),
+                flex_direction: FlexDirection::Column,
+                padding: UiRect::all(Val::Px(12.0)),
+                overflow: Overflow::clip(),
+                ..default()
+            },
+            BackgroundColor(Color::srgba(0.02, 0.02, 0.04, 0.88)),
+            GlobalZIndex(900),
+        ))
+        .with_children(|overlay| {
+            // Header row
+            overlay
+                .spawn(Node {
+                    flex_direction: FlexDirection::Row,
+                    justify_content: JustifyContent::SpaceBetween,
+                    align_items: AlignItems::Center,
+                    margin: UiRect::bottom(Val::Px(6.0)),
+                    flex_shrink: 0.0,
+                    ..default()
+                })
+                .with_children(|header| {
+                    header.spawn((
+                        Text::new("LOG OUTPUT"),
+                        TextFont { font_size: 11.0, ..default() },
+                        TextColor(theme.text_dim),
+                    ));
+                    header.spawn((
+                        Text::new("[F12 to close]"),
+                        TextFont { font_size: 11.0, ..default() },
+                        TextColor(theme.text_dim),
+                    ));
+                });
+
+            // Separator line
+            overlay.spawn((
+                Node {
+                    width: Val::Percent(100.0),
+                    height: Val::Px(1.0),
+                    margin: UiRect::bottom(Val::Px(6.0)),
+                    flex_shrink: 0.0,
+                    ..default()
+                },
+                BackgroundColor(Color::srgba(1.0, 1.0, 1.0, 0.1)),
+            ));
+
+            // Log content — one Text entity per line, with ANSI-colored spans
+            overlay
+                .spawn(Node {
+                    flex_grow: 1.0,
+                    overflow: Overflow::clip(),
+                    flex_direction: FlexDirection::ColumnReverse,
+                    ..default()
+                })
+                .with_children(|scroll_area| {
+                    scroll_area
+                        .spawn(Node {
+                            flex_direction: FlexDirection::Column,
+                            ..default()
+                        })
+                        .with_children(|content| {
+                            for line_spans in &display {
+                                // First span becomes the root Text
+                                let first = &line_spans[0];
+                                let mut line_entity = content.spawn((
+                                    LogOverlayText,
+                                    Text::new(&first.text),
+                                    TextFont { font_size: LOG_FONT_SIZE, ..default() },
+                                    TextColor(first.color),
+                                ));
+
+                                // Remaining spans as children
+                                if line_spans.len() > 1 {
+                                    line_entity.with_children(|parent| {
+                                        for span in &line_spans[1..] {
+                                            parent.spawn((
+                                                TextSpan::new(&span.text),
+                                                TextFont { font_size: LOG_FONT_SIZE, ..default() },
+                                                TextColor(span.color),
+                                            ));
+                                        }
+                                    });
+                                }
+                            }
+                        });
+                });
+        });
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod analyzer;
 mod config;
+mod log_viewer;
 pub mod error;
 pub mod input;
 mod menu;
@@ -139,7 +140,8 @@ fn main() {
         .add_plugins(scanner::ScannerPlugin)
         .add_plugins(analyzer::AnalyzerPlugin)
         .add_plugins(menu::MenuPlugin)
-        .add_plugins(player::PlayerPlugin);
+        .add_plugins(player::PlayerPlugin)
+        .add_plugins(log_viewer::LogViewerPlugin);
 
     if vendor_ready {
         app.add_systems(Startup, skip_setup);

--- a/src/menu/components.rs
+++ b/src/menu/components.rs
@@ -44,6 +44,7 @@ pub enum SettingsAction {
     BeamDown,
     BatchUp,
     BatchDown,
+    ToggleShowLogs,
     RestoreDefaults,
     Close,
 }
@@ -66,6 +67,7 @@ pub enum SettingsField {
     Beam,
     Batch,
     Fullscreen,
+    ShowLogs,
 }
 
 #[derive(Component)]
@@ -116,6 +118,9 @@ pub struct AboutOverlay;
 
 #[derive(Component)]
 pub struct AboutCloseButton;
+
+#[derive(Component)]
+pub struct SortButton(pub super::LibrarySort);
 
 #[derive(Resource)]
 pub struct LanguagePickerTarget {

--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -126,6 +126,10 @@ impl Plugin for MenuPlugin {
             )
             .add_systems(
                 Update,
+                handle_sort_click.run_if(in_state(AppState::Menu)),
+            )
+            .add_systems(
+                Update,
                 sidebar::update_about_link_hover
                     .run_if(in_state(AppState::Menu)),
             )
@@ -158,9 +162,37 @@ impl Plugin for MenuPlugin {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LibrarySort {
+    #[default]
+    Title,
+    Artist,
+    Album,
+}
+
+impl LibrarySort {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Title => "Title",
+            Self::Artist => "Artist",
+            Self::Album => "Album",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Title => Self::Artist,
+            Self::Artist => Self::Album,
+            Self::Album => Self::Title,
+        }
+    }
+}
+
 #[derive(Resource, Default)]
 pub(crate) struct MenuState {
     pub(crate) search_query: String,
+    pub(crate) sort: LibrarySort,
+    pub(crate) sorted_indices: Vec<usize>,
 }
 
 #[derive(Resource)]
@@ -220,10 +252,42 @@ fn kick_off_cache_stats(mut commands: Commands) {
     sidebar::start_cache_stats_computation(&mut commands);
 }
 
+fn compute_sorted_indices(library: &SongLibrary, sort: LibrarySort) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..library.songs.len()).collect();
+    match sort {
+        LibrarySort::Title => indices.sort_by(|&a, &b| {
+            library.songs[a].display_title().to_lowercase().cmp(
+                &library.songs[b].display_title().to_lowercase(),
+            )
+        }),
+        LibrarySort::Artist => indices.sort_by(|&a, &b| {
+            let cmp = library.songs[a].display_artist().to_lowercase().cmp(
+                &library.songs[b].display_artist().to_lowercase(),
+            );
+            cmp.then_with(|| {
+                library.songs[a].display_title().to_lowercase().cmp(
+                    &library.songs[b].display_title().to_lowercase(),
+                )
+            })
+        }),
+        LibrarySort::Album => indices.sort_by(|&a, &b| {
+            let cmp = library.songs[a].album.to_lowercase().cmp(
+                &library.songs[b].album.to_lowercase(),
+            );
+            cmp.then_with(|| {
+                library.songs[a].display_title().to_lowercase().cmp(
+                    &library.songs[b].display_title().to_lowercase(),
+                )
+            })
+        }),
+    }
+    indices
+}
+
 fn build_menu(
     mut commands: Commands,
     library: Res<SongLibrary>,
-    menu_state: Res<MenuState>,
+    mut menu_state: ResMut<MenuState>,
     art_cache: Res<AlbumArtCache>,
     theme: Res<UiTheme>,
     config: Res<crate::config::AppConfig>,
@@ -233,6 +297,7 @@ fn build_menu(
     mut focus: ResMut<MenuFocus>,
 ) {
     *focus = MenuFocus::default();
+    menu_state.sorted_indices = compute_sorted_indices(&library, menu_state.sort);
     let has_folder = config.last_folder.as_ref().is_some_and(|f| f.is_dir());
 
     let logo_handle: Handle<Image> = asset_server.load("images/logo.png");
@@ -398,6 +463,45 @@ fn build_main_area(
             Visibility::Hidden,
         ));
 
+        // Sort bar
+        main.spawn(Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            column_gap: Val::Px(8.0),
+            margin: UiRect::bottom(Val::Px(4.0)),
+            flex_shrink: 0.0,
+            ..default()
+        })
+        .with_children(|bar| {
+            bar.spawn((
+                Text::new("Sort:"),
+                TextFont { font_size: 12.0, ..default() },
+                TextColor(theme.text_dim),
+            ));
+            for sort_option in [LibrarySort::Title, LibrarySort::Artist, LibrarySort::Album] {
+                let is_active = menu_state.sort == sort_option;
+                let bg = if is_active { theme.accent } else { theme.popup_btn };
+                let text_color = if is_active { Color::WHITE } else { theme.text_secondary };
+                bar.spawn((
+                    SortButton(sort_option),
+                    Button,
+                    Node {
+                        padding: UiRect::new(Val::Px(10.0), Val::Px(10.0), Val::Px(4.0), Val::Px(4.0)),
+                        border_radius: BorderRadius::all(Val::Px(4.0)),
+                        ..default()
+                    },
+                    BackgroundColor(bg),
+                ))
+                .with_children(|btn| {
+                    btn.spawn((
+                        Text::new(sort_option.label()),
+                        TextFont { font_size: 12.0, ..default() },
+                        TextColor(text_color),
+                    ));
+                });
+            }
+        });
+
         main.spawn((
             SongListRoot,
             Node {
@@ -413,10 +517,12 @@ fn build_main_area(
         .with_children(|list| {
             let query = menu_state.search_query.to_lowercase();
             let active_profile = profiles.active.as_deref();
-            for (i, song) in library.songs.iter().enumerate() {
+            for &i in &menu_state.sorted_indices {
+                let song = &library.songs[i];
                 let visible = query.is_empty()
                     || song.display_title().to_lowercase().contains(&query)
-                    || song.display_artist().to_lowercase().contains(&query);
+                    || song.display_artist().to_lowercase().contains(&query)
+                    || song.album.to_lowercase().contains(&query);
                 let art = art_cache.handles.get(i).and_then(|h| h.clone());
                 let best = active_profile
                     .and_then(|p| profiles.best_score(&song.file_hash, p));
@@ -466,6 +572,58 @@ fn build_empty_state(parent: &mut ChildSpawnerCommands, theme: &UiTheme) {
                 TextColor(theme.text_dim),
             ));
         });
+}
+
+fn handle_sort_click(
+    interaction_query: Query<(&Interaction, &SortButton), Changed<Interaction>>,
+    mut menu_state: ResMut<MenuState>,
+    library: Res<SongLibrary>,
+    // Trigger a full menu rebuild by re-entering the state
+    mut commands: Commands,
+    menu_root: Query<Entity, With<MenuRoot>>,
+    art_cache: Res<AlbumArtCache>,
+    theme: Res<UiTheme>,
+    config: Res<AppConfig>,
+    asset_server: Res<AssetServer>,
+    profiles: Res<ProfileStore>,
+    cache_stats: Res<sidebar::CacheStats>,
+    mut focus: ResMut<MenuFocus>,
+) {
+    for (interaction, sort_btn) in &interaction_query {
+        if matches!(interaction, Interaction::Pressed) && menu_state.sort != sort_btn.0 {
+            menu_state.sort = sort_btn.0;
+            menu_state.sorted_indices = compute_sorted_indices(&library, menu_state.sort);
+
+            // Rebuild menu
+            for entity in &menu_root {
+                commands.entity(entity).despawn();
+            }
+            *focus = MenuFocus::default();
+
+            let has_folder = config.last_folder.as_ref().is_some_and(|f| f.is_dir());
+            let logo_handle: Handle<Image> = asset_server.load("images/logo.png");
+            let icon_font = IconFont(asset_server.load("fonts/fa-solid-900.ttf"));
+            commands.insert_resource(icon_font.clone());
+
+            commands
+                .spawn((
+                    MenuRoot,
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Percent(100.0),
+                        flex_direction: FlexDirection::Row,
+                        ..default()
+                    },
+                    BackgroundColor(theme.bg),
+                ))
+                .with_children(|root| {
+                    sidebar::build_sidebar(root, &theme, has_folder, logo_handle, &icon_font, &profiles, &cache_stats);
+                    build_main_area(root, &library, &menu_state, &art_cache, &theme, &icon_font, &profiles);
+                });
+
+            break;
+        }
+    }
 }
 
 fn handle_song_click(

--- a/src/menu/nav.rs
+++ b/src/menu/nav.rs
@@ -218,6 +218,7 @@ pub(super) fn apply_menu_focus_styling(
 
 pub(super) fn scroll_to_focused(
     focus: Res<MenuFocus>,
+    menu_state: Res<super::MenuState>,
     mut scroll_query: Query<(&mut ScrollPosition, &ComputedNode), With<SongListRoot>>,
     card_query: Query<(&SongCard, &Node, &ComputedNode)>,
 ) {
@@ -234,22 +235,25 @@ pub(super) fn scroll_to_focused(
         return;
     }
 
-    let gap = 8.0;
-    let mut cards: Vec<(usize, f32)> = card_query
-        .iter()
-        .filter(|(_, node, _)| node.display != Display::None)
-        .map(|(card, _, computed)| {
-            (
+    // Build a height lookup from the ECS
+    let mut height_map: std::collections::HashMap<usize, f32> = std::collections::HashMap::new();
+    for (card, node, computed) in &card_query {
+        if node.display != Display::None {
+            height_map.insert(
                 card.song_index,
                 computed.size().y * computed.inverse_scale_factor(),
-            )
-        })
-        .collect();
-    cards.sort_by_key(|(idx, _)| *idx);
+            );
+        }
+    }
 
+    // Walk in sorted (visual) order
+    let gap = 8.0;
     let mut y = 0.0;
-    for (idx, height) in &cards {
-        if *idx == focus.song_index {
+    for &idx in &menu_state.sorted_indices {
+        let Some(&height) = height_map.get(&idx) else {
+            continue;
+        };
+        if idx == focus.song_index {
             if y < scroll_pos.y {
                 scroll_pos.y = y;
             } else if y + height > scroll_pos.y + list_height {

--- a/src/menu/settings.rs
+++ b/src/menu/settings.rs
@@ -13,7 +13,7 @@ const MODELS: &[&str] = &["large-v3", "large-v3-turbo", "medium", "small", "base
 #[derive(Resource)]
 pub struct SettingsFocus(pub usize);
 
-const SETTINGS_ROW_COUNT: usize = 7;
+const SETTINGS_ROW_COUNT: usize = 8;
 
 struct SettingsRowMapping {
     enter: SettingsAction,
@@ -32,6 +32,7 @@ const fn row_mapping(
 fn settings_rows() -> [SettingsRowMapping; SETTINGS_ROW_COUNT] {
     [
         row_mapping(SettingsAction::ToggleFullscreen, None, None),
+        row_mapping(SettingsAction::ToggleShowLogs, None, None),
         row_mapping(
             SettingsAction::SeparatorNext,
             Some(SettingsAction::SeparatorPrev),
@@ -107,25 +108,30 @@ pub fn spawn_settings_popup(
                         SettingsValueText(SettingsField::Fullscreen),
                         &[("Switch", SettingsAction::ToggleFullscreen)],
                         "Toggle between fullscreen and windowed mode", 0);
+                    let logs_label = if config.show_logs() { "On" } else { "Off" };
+                    spawn_settings_row(card, theme, "Show Logs", logs_label,
+                        SettingsValueText(SettingsField::ShowLogs),
+                        &[("Toggle", SettingsAction::ToggleShowLogs)],
+                        "Show log overlay (F12). Useful for debugging analysis issues", 1);
 
                     spawn_settings_section(card, theme, "Analyzer");
                     let sep_label = separator_display(config.separator());
                     spawn_settings_row(card, theme, "Separator", sep_label,
                         SettingsValueText(SettingsField::Separator),
                         &[("<", SettingsAction::SeparatorPrev), (">", SettingsAction::SeparatorNext)],
-                        "Karaoke removes backing vocals for cleaner lyrics; Demucs is faster", 1);
+                        "Karaoke removes backing vocals for cleaner lyrics; Demucs is faster", 2);
                     spawn_settings_row(card, theme, "Model", config.whisper_model(),
                         SettingsValueText(SettingsField::Model),
                         &[("<", SettingsAction::ModelPrev), (">", SettingsAction::ModelNext)],
-                        "turbo is fastest, v3 is most accurate", 2);
+                        "turbo is fastest, v3 is most accurate", 3);
                     spawn_settings_row(card, theme, "Beam size", &config.beam_size().to_string(),
                         SettingsValueText(SettingsField::Beam),
                         &[("-", SettingsAction::BeamDown), ("+", SettingsAction::BeamUp)],
-                        "Higher values improve accuracy at the cost of speed", 3);
+                        "Higher values improve accuracy at the cost of speed", 4);
                     spawn_settings_row(card, theme, "Batch size", &config.batch_size().to_string(),
                         SettingsValueText(SettingsField::Batch),
                         &[("-", SettingsAction::BatchDown), ("+", SettingsAction::BatchUp)],
-                        "Higher values use more memory but process faster", 4);
+                        "Higher values use more memory but process faster", 5);
 
                     card.spawn((
                         Text::new("Changes apply to future analyses. Use the re-analyze button on song cards to apply."),
@@ -137,8 +143,8 @@ pub fn spawn_settings_popup(
                         },
                     ));
 
-                    spawn_settings_wide_btn(card, "Restore Defaults", SettingsAction::RestoreDefaults, theme, 5);
-                    spawn_settings_wide_btn(card, "Close", SettingsAction::Close, theme, 6);
+                    spawn_settings_wide_btn(card, "Restore Defaults", SettingsAction::RestoreDefaults, theme, 6);
+                    spawn_settings_wide_btn(card, "Close", SettingsAction::Close, theme, 7);
                 });
         });
 }
@@ -303,6 +309,13 @@ fn dispatch_settings_action(
                 set_settings_text(value_texts, SettingsField::Fullscreen, new_label);
             }
         }
+        SettingsAction::ToggleShowLogs => {
+            let new_val = !config.show_logs();
+            config.show_logs = Some(new_val);
+            config.save();
+            let label = if new_val { "On" } else { "Off" };
+            set_settings_text(value_texts, SettingsField::ShowLogs, label);
+        }
         SettingsAction::SeparatorPrev | SettingsAction::SeparatorNext => {
             let current = config.separator();
             let idx = SEPARATORS.iter().position(|(k, _)| *k == current).unwrap_or(0);
@@ -359,6 +372,7 @@ fn dispatch_settings_action(
             config.beam_size = None;
             config.batch_size = None;
             config.fullscreen = None;
+            config.show_logs = None;
             config.save();
             set_settings_text(value_texts, SettingsField::Separator, separator_display(config.separator()));
             set_settings_text(value_texts, SettingsField::Model, config.whisper_model());
@@ -366,6 +380,8 @@ fn dispatch_settings_action(
             set_settings_text(value_texts, SettingsField::Batch, &config.batch_size().to_string());
             let fs_label = if config.is_fullscreen() { "Fullscreen" } else { "Windowed" };
             set_settings_text(value_texts, SettingsField::Fullscreen, fs_label);
+            let logs_label = if config.show_logs() { "On" } else { "Off" };
+            set_settings_text(value_texts, SettingsField::ShowLogs, logs_label);
             if let Ok(mut window) = windows.single_mut() {
                 window.mode = if config.is_fullscreen() {
                     WindowMode::BorderlessFullscreen(bevy::window::MonitorSelection::Current)
@@ -472,12 +488,13 @@ pub fn handle_settings_click(
             Interaction::Hovered => {
                 let row_for_action = match settings_btn.action {
                     SettingsAction::ToggleFullscreen => Some(0),
-                    SettingsAction::SeparatorPrev | SettingsAction::SeparatorNext => Some(1),
-                    SettingsAction::ModelPrev | SettingsAction::ModelNext => Some(2),
-                    SettingsAction::BeamDown | SettingsAction::BeamUp => Some(3),
-                    SettingsAction::BatchDown | SettingsAction::BatchUp => Some(4),
-                    SettingsAction::RestoreDefaults => Some(5),
-                    SettingsAction::Close => Some(6),
+                    SettingsAction::ToggleShowLogs => Some(1),
+                    SettingsAction::SeparatorPrev | SettingsAction::SeparatorNext => Some(2),
+                    SettingsAction::ModelPrev | SettingsAction::ModelNext => Some(3),
+                    SettingsAction::BeamDown | SettingsAction::BeamUp => Some(4),
+                    SettingsAction::BatchDown | SettingsAction::BatchUp => Some(5),
+                    SettingsAction::RestoreDefaults => Some(6),
+                    SettingsAction::Close => Some(7),
                 };
                 if let (Some(sf), Some(row)) = (&mut settings_focus, row_for_action) {
                     sf.0 = row;


### PR DESCRIPTION
## What's new

### In-App Log Viewer
- **F12 hotkey** toggles a semi-transparent log overlay at the bottom of the screen
- Tails `~/.nightingale/nightingale.log` in real-time (background thread, polls every 500ms)
- **ANSI color support** — parses terminal escape codes and renders actual colors (red errors, green info, yellow warnings, etc.)
- Ring buffer of 500 lines, displays last 60
- Also togglable via **Settings → Show Logs** (persisted in config.json)
- Useful for debugging analysis failures without needing a terminal open

### Library Sort
- **Sort bar** with Title / Artist / Album buttons above the song list
- Active sort highlighted with accent color
- Secondary sort by title when grouping by artist or album
- Search now also matches album names
- Scroll position correctly tracks focused song in sorted order

## Screenshots
Screenshots in comment below.