### PR TITLE
Set NLTK_DATA to keep nltk_data inside models directory

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -117,6 +117,7 @@ fn spawn_server() -> Result<ServerProcess, NightingaleError> {
         .env("PYTORCH_ENABLE_MPS_FALLBACK", "1")
         .env("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
         .env("HF_HUB_DISABLE_SYMLINKS_WARNING", "1")
+        .env("NLTK_DATA", models.join("nltk_data"))
         .arg(&script)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
## Summary
- WhisperX depends on NLTK, which defaults to writing its data to `~/nltk_data`, polluting the user's home directory
- Sets the `NLTK_DATA` env var on the analyzer subprocess so NLTK data is stored inside the models directory, alongside the existing `torch` and `huggingface` data

Fixes #26