### PR TITLE
Add optional HTTP proxy for model/tool downloads

### DIFF
--- a/app-core/src/config.rs
+++ b/app-core/src/config.rs
@@ -112,6 +112,9 @@ pub struct AppConfig {
     pub vocal_detection_threshold_pct: Option<f64>,
     pub auto_analyze: Option<bool>,
     pub language_overrides: Option<HashMap<String, String>>,
+    /// Optional HTTP proxy (e.g. `http://127.0.0.1:7890`), applied at startup
+    /// by `apply_proxy_env`.
+    pub proxy: Option<String>,
 }
 
 fn default_data_path_option() -> Option<PathBuf> {
@@ -146,6 +149,30 @@ impl Default for AppConfig {
             vocal_detection_threshold_pct: None,
             auto_analyze: None,
             language_overrides: None,
+            proxy: None,
+        }
+    }
+}
+
+/// Set the process proxy env vars from `cfg.proxy` (no-op if unset). `ureq` and
+/// the analyzer subprocess pick them up; existing env vars are left untouched.
+pub fn apply_proxy_env(cfg: &AppConfig) {
+    let Some(proxy) = cfg.proxy.as_deref().map(str::trim).filter(|s| !s.is_empty()) else {
+        return;
+    };
+    for key in [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ] {
+        if std::env::var_os(key).is_none() {
+            // Safe: called once at startup before other threads read the env.
+            unsafe {
+                std::env::set_var(key, proxy);
+            }
         }
     }
 }

--- a/app-core/src/lib.rs
+++ b/app-core/src/lib.rs
@@ -25,7 +25,7 @@ pub use cache::{
     CacheDir, CachePaths, CacheStats, cache_roots, change_app_data_path, clear_models,
     clear_videos, default_nightingale_dir, nightingale_dir, normalized_target_path, same_path,
 };
-pub use config::{AppConfig, LibrarySource};
+pub use config::{AppConfig, LibrarySource, apply_proxy_env};
 pub use library_db::{init_library, library_db_path};
 pub use library_menu::{LibraryMenuItem, LibraryMenuItems, load_library_menu_items};
 pub use library_model::{LibraryMenuFilters, LoadSongsParams, SongsMeta, SongsStore};

--- a/client/src-server/src/main.rs
+++ b/client/src-server/src/main.rs
@@ -63,6 +63,9 @@ async fn main() {
         )
         .init();
 
+    // Apply the configured proxy before any downloads run.
+    app_core::apply_proxy_env(&app_core::AppConfig::load());
+
     if let Err(e) = app_core::startup() {
         tracing::error!("startup failed: {e}");
         std::process::exit(1);

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -78,6 +78,9 @@ fn minimize_window(window: tauri::WebviewWindow) -> Result<(), String> {
 pub fn run() {
     logging::init();
 
+    // Apply the configured proxy before any downloads run.
+    app_core::apply_proxy_env(&app_core::AppConfig::load());
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())

--- a/client/src/types/AppConfig.ts
+++ b/client/src/types/AppConfig.ts
@@ -37,4 +37,9 @@ export type AppConfig = {
   vocal_detection_threshold_pct: number | null;
   auto_analyze: boolean | null;
   language_overrides: { [key in string]: string } | null;
+  /**
+   * Optional HTTP proxy (e.g. `http://127.0.0.1:7890`), applied at startup
+   * by `apply_proxy_env`.
+   */
+  proxy: string | null;
 };


### PR DESCRIPTION
## Problem

On restricted networks, Nightingale's downloads stall
or fail and there is no way to point them at a proxy:

- Analysis hangs at **58%** — faster-whisper model, served via Hugging Face
  Xet storage, never finishes downloading.
- Analysis hangs at **80%** — the wav2vec2 alignment model.
- First-run setup fails downloading ffmpeg / uv / PyTorch.

The only workaround is launching the binary from a shell with `HTTPS_PROXY`
set, which does **not** work when the app is opened by double-clicking
(macOS GUI processes don't inherit the shell environment).

## Change

Add an optional `proxy` field to `AppConfig`. At startup, `apply_proxy_env`
writes it into the process environment (`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`
plus lowercase variants) when set.

This is enough to route **every** download through the proxy with no
per-call-site changes, because:

- the HTTP client is `ureq` v3, which reads these variables automatically, and
- the Python analyzer subprocess inherits the app's environment
  (`spawn_server` doesn't clear it), and huggingface_hub / torch / nltk / uv
  all honor the standard proxy variables.

Any proxy variable already present in the environment takes precedence, so the
existing "launch with `HTTPS_PROXY=…`" workaround still wins.

Scope is intentionally limited to **HTTP proxies** (no SOCKS): the Python side
(torch.hub / urllib) doesn't handle SOCKS reliably.

## Usage

No UI — set it in `~/.nightingale/config.json`:

    { "proxy": "http://127.0.0.1:7890" }

Restart the app (the variables are applied once at startup).

## Wiring

- `app-core/src/config.rs` — new `proxy` field + `apply_proxy_env`.
- `client/src-tauri/src/lib.rs` and `client/src-server/src/main.rs` — call it
  early at startup, before any downloads.
- Regenerated the ts-rs binding (`client/src/types/AppConfig.ts`).

## Testing

- `cargo test -p app-core` — passes.
- `cargo check` of the `server` and Tauri (`Nightingale`) crates — compiles.
- Manually verified downloads route through an HTTP proxy and analysis then
  gets past 58% / 80%.