### PR TITLE
docs: update microphone support and HTTPS section

### DIFF
--- a/site/docs/src/self-hosted.md
+++ b/site/docs/src/self-hosted.md
@@ -62,7 +62,7 @@ If your songs are on the server at `/srv/music/karaoke`, enter that full path in
 
 ## Microphone support and HTTPS
 
-Browsers block microphone capture on normal HTTP pages unless the page is `localhost`. Since `<hostname>.local` is not treated as secure, mic capture needs HTTPS. This can vary per-browser and per-setup, if mic capture works for you via HTTP-connection, feel free to skip this step.
+Browsers block microphone capture on normal HTTP pages unless the page is `localhost`. Since `<hostname>.local` is not treated as secure, mic capture needs HTTPS. This can vary per-browser and per-setup, if mic capture works for you via HTTP-connection, feel free to skip this step (If you still want to use it via HTTP you must [config you browser](https://www.windowstechit.com/28309/insecure-origins-treated-as-secure/)).
 
 Nightingale already serves HTTPS at:
 


### PR DESCRIPTION
Nightingale is awesome.
I am  using it in my local network and i cant use mic, so i think it is worth it to have a workaround in the docs.
So I Added note about configuring browser for HTTP microphone capture, with a link for major browsers.

