### PR TITLE
feat: improve lyric gap countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ below.
 
 ## [Unreleased]
 
+### Improvements
+
+- Long gaps between lyric lines now show a compact countdown beneath the song details, while the circular three-second countdown bubble stays beside the lyric line as the next line approaches. The next lyric block is no longer previewed across an instrumental break.
+
 ## [1.1.0] - 2026-08-14
 
 ### Features

--- a/client/src/components/playback/lyrics-display.tsx
+++ b/client/src/components/playback/lyrics-display.tsx
@@ -2,18 +2,15 @@ import { usePlaybackTransportActions, usePlaybackTransportState } from "@/contex
 import { cn } from "@/lib/utils";
 import type { AppConfig } from "@/types/AppConfig";
 import type { Segment, Word } from "@/types/Transcript";
+import {
+  CAPTION_HIDE_SEC,
+  findCurrentSegment,
+  GAP_THRESHOLD_SEC,
+  LYRICS_LEAD,
+  SEGMENT_LINGER,
+  WORD_HIGHLIGHT_LEAD,
+} from "@/utils/playback/lyrics-gap";
 import { memo, useEffect, useRef, useState } from "react";
-
-// Timing offsets: lyrics/words appear slightly before their actual start
-// so the visual transition feels in sync with the audio.
-const LYRICS_LEAD = 0.15;
-const WORD_HIGHLIGHT_LEAD = 0.25;
-
-const COUNTDOWN_DURATION = 3.0;
-const COUNTDOWN_GAP_THRESHOLD = 3.5;
-
-// Grace period after a segment ends before it disappears
-const SEGMENT_LINGER = 0.5;
 
 interface WordStyle {
   rgb: string;
@@ -52,46 +49,6 @@ function interpolateStyle(from: WordStyle, to: WordStyle, t: number): WordStyle 
     rgb: `rgb(${r},${g},${b})`,
     opacity: lerp(from.opacity, to.opacity, p),
   };
-}
-
-// --- Segment search ---
-
-/**
- * Finds the segment index that should be displayed at a given `time`.
- * Uses `hint` (the last known index) to skip already-passed segments.
- * Prefers the *next* segment when the current time falls in the lead-in window.
- */
-function findCurrentSegment(segments: Segment[], time: number, hint: number): number {
-  const start = hint < segments.length && time >= segments[hint].start - LYRICS_LEAD ? hint : 0;
-
-  for (let i = start; i < segments.length; i++) {
-    if (time >= segments[i].end + SEGMENT_LINGER) {
-      const next = i + 1;
-
-      // Through a short pause, keep the finished line current until the next
-      // line's lead-in begins, so the switch happens when the new line starts
-      // rather than when the old one ends.
-      if (
-        next < segments.length &&
-        segments[next].start - segments[i].end < COUNTDOWN_GAP_THRESHOLD &&
-        time < segments[next].start - LYRICS_LEAD
-      ) {
-        return i;
-      }
-
-      continue;
-    }
-
-    // If we're already in the lead-in of the next segment, jump ahead
-    const next = i + 1;
-    if (next < segments.length && time >= segments[next].start - LYRICS_LEAD) {
-      return next;
-    }
-
-    return i;
-  }
-
-  return Math.max(0, segments.length - 1);
 }
 
 // --- Per-frame DOM updates (called via rAF subscriber, no React re-renders) ---
@@ -247,21 +204,34 @@ function LyricsDisplayImpl({
 
       const gapBefore = idx === 0 ? seg.start : seg.start - segments[idx - 1].end;
       const timeUntil = seg.start - time;
+      // Circular countdown bubble beside the lyric line for the final seconds
+      // of a long gap. The HUD caption hides in this window (<= CAPTION_HIDE_SEC),
+      // so the bubble is the single countdown source while the upcoming lyric
+      // previews.
       const showCountdown =
-        gapBefore >= COUNTDOWN_GAP_THRESHOLD && timeUntil > 0 && timeUntil <= COUNTDOWN_DURATION;
+        gapBefore >= GAP_THRESHOLD_SEC && timeUntil > 0 && timeUntil <= CAPTION_HIDE_SEC;
 
       // After a line ends, keep it on screen through a short pause until the
       // next line starts (findCurrentSegment holds idx on the finished line).
       const nextStart = idx + 1 < segments.length ? segments[idx + 1].start : Infinity;
       const bridgeShortGap =
-        time > seg.end + SEGMENT_LINGER && nextStart - seg.end < COUNTDOWN_GAP_THRESHOLD;
+        time > seg.end + SEGMENT_LINGER && nextStart - seg.end < GAP_THRESHOLD_SEC;
 
       const showCurrent = isActive || showCountdown || bridgeShortGap;
       const hasNext = idx + 1 < segments.length;
 
+      // Only preview a second line when it belongs to the same continuous
+      // vocal passage: the current line must not itself be an upcoming
+      // after-break line (inLongGap), and the gap into the next line must be
+      // short. Never preview the next lyric block before or during a longer
+      // instrumental break; once that block starts, its own following line
+      // may preview only when that next gap is short.
+      const inLongGap = gapBefore >= GAP_THRESHOLD_SEC && timeUntil > LYRICS_LEAD;
+      const gapAfter = nextStart - seg.end;
+      const showNext = showCurrent && hasNext && !inLongGap && gapAfter < GAP_THRESHOLD_SEC;
+
       if (containerRef.current) containerRef.current.style.display = showCurrent ? "" : "none";
-      if (nextContainerRef.current)
-        nextContainerRef.current.style.display = showCurrent && hasNext ? "" : "none";
+      if (nextContainerRef.current) nextContainerRef.current.style.display = showNext ? "" : "none";
 
       updateCountdown(countdownRef.current, showCountdown, timeUntil);
       // Bridged finished lines are past every word's end, so treating them as

--- a/client/src/components/playback/lyrics-display.tsx
+++ b/client/src/components/playback/lyrics-display.tsx
@@ -3,14 +3,14 @@ import { cn } from "@/lib/utils";
 import type { AppConfig } from "@/types/AppConfig";
 import type { Segment, Word } from "@/types/Transcript";
 import {
-  CAPTION_HIDE_SEC,
+  BUBBLE_COUNTDOWN_SEC,
   findCurrentSegment,
   GAP_THRESHOLD_SEC,
   LYRICS_LEAD,
   SEGMENT_LINGER,
   WORD_HIGHLIGHT_LEAD,
 } from "@/utils/playback/lyrics-gap";
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 interface WordStyle {
   rgb: string;
@@ -181,6 +181,7 @@ function LyricsDisplayImpl({
   );
 
   const hintRef = useRef(0);
+  const renderedIdxRef = useRef(segIdx);
   const wordRefs = useRef<(HTMLSpanElement | null)[]>([]);
   const countdownRef = useRef<HTMLSpanElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -190,6 +191,7 @@ function LyricsDisplayImpl({
     if (segments.length === 0) return;
 
     let raf = 0;
+    let pendingRaf = 0;
     let cancelled = false;
 
     const apply = (time: number) => {
@@ -199,17 +201,33 @@ function LyricsDisplayImpl({
         setSegIdx(idx);
       }
 
+      // setSegIdx only schedules a re-render; until React commits, the container
+      // refs still render the previous segment. Applying the new index's
+      // visibility to that stale DOM would transiently hide or misplace lines,
+      // so defer per-frame updates until the render has caught up.
+      if (idx !== renderedIdxRef.current) {
+        // Paused: React commits outside the rAF loop, so re-apply on the next
+        // frame once the render for `idx` has committed.
+        if (!animate && !pendingRaf) {
+          pendingRaf = requestAnimationFrame(() => {
+            pendingRaf = 0;
+            if (!cancelled) apply(getCurrentTime());
+          });
+        }
+        return;
+      }
+
       const seg = segments[idx];
       const isActive = time >= seg.start - LYRICS_LEAD && time <= seg.end + SEGMENT_LINGER;
 
       const gapBefore = idx === 0 ? seg.start : seg.start - segments[idx - 1].end;
       const timeUntil = seg.start - time;
       // Circular countdown bubble beside the lyric line for the final seconds
-      // of a long gap. The HUD caption hides in this window (<= CAPTION_HIDE_SEC),
-      // so the bubble is the single countdown source while the upcoming lyric
+      // of a long gap. The HUD caption keeps running for the whole gap, so the
+      // bubble is the lyric-side companion countdown while the upcoming lyric
       // previews.
       const showCountdown =
-        gapBefore >= GAP_THRESHOLD_SEC && timeUntil > 0 && timeUntil <= CAPTION_HIDE_SEC;
+        gapBefore >= GAP_THRESHOLD_SEC && timeUntil > 0 && timeUntil <= BUBBLE_COUNTDOWN_SEC;
 
       // After a line ends, keep it on screen through a short pause until the
       // next line starts (findCurrentSegment holds idx on the finished line).
@@ -249,12 +267,26 @@ function LyricsDisplayImpl({
       return () => {
         cancelled = true;
         cancelAnimationFrame(raf);
+        cancelAnimationFrame(pendingRaf);
       };
     }
 
     apply(getCurrentTime());
-    return subscribe((time) => apply(time));
+    const unsubscribe = subscribe((time) => apply(time));
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(pendingRaf);
+      unsubscribe();
+    };
   }, [segments, subscribe, getCurrentTime, animate]);
+
+  // Keep `renderedIdxRef` in sync with the index React has actually committed
+  // to the DOM. It must be updated here (after commit) rather than during
+  // render so an interrupted concurrent render cannot claim an uncommitted
+  // index, which would let the rAF updater mutate visibility against stale DOM.
+  useLayoutEffect(() => {
+    renderedIdxRef.current = segIdx;
+  }, [segIdx]);
 
   if (segments.length === 0) {
     return null;

--- a/client/src/components/playback/lyrics-display.tsx
+++ b/client/src/components/playback/lyrics-display.tsx
@@ -10,7 +10,7 @@ import {
   SEGMENT_LINGER,
   WORD_HIGHLIGHT_LEAD,
 } from "@/utils/playback/lyrics-gap";
-import { memo, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { memo, useLayoutEffect, useRef, useState } from "react";
 
 interface WordStyle {
   rgb: string;
@@ -182,16 +182,17 @@ function LyricsDisplayImpl({
 
   const hintRef = useRef(0);
   const renderedIdxRef = useRef(segIdx);
+  const appliedIdxRef = useRef<number | null>(null);
+  const applyRef = useRef<((time: number) => void) | null>(null);
   const wordRefs = useRef<(HTMLSpanElement | null)[]>([]);
   const countdownRef = useRef<HTMLSpanElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const nextContainerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (segments.length === 0) return;
 
     let raf = 0;
-    let pendingRaf = 0;
     let cancelled = false;
 
     const apply = (time: number) => {
@@ -206,14 +207,6 @@ function LyricsDisplayImpl({
       // visibility to that stale DOM would transiently hide or misplace lines,
       // so defer per-frame updates until the render has caught up.
       if (idx !== renderedIdxRef.current) {
-        // Paused: React commits outside the rAF loop, so re-apply on the next
-        // frame once the render for `idx` has committed.
-        if (!animate && !pendingRaf) {
-          pendingRaf = requestAnimationFrame(() => {
-            pendingRaf = 0;
-            if (!cancelled) apply(getCurrentTime());
-          });
-        }
         return;
       }
 
@@ -238,15 +231,13 @@ function LyricsDisplayImpl({
       const showCurrent = isActive || showCountdown || bridgeShortGap;
       const hasNext = idx + 1 < segments.length;
 
-      // Only preview a second line when it belongs to the same continuous
-      // vocal passage: the current line must not itself be an upcoming
-      // after-break line (inLongGap), and the gap into the next line must be
-      // short. Never preview the next lyric block before or during a longer
-      // instrumental break; once that block starts, its own following line
-      // may preview only when that next gap is short.
       const inLongGap = gapBefore >= GAP_THRESHOLD_SEC && timeUntil > LYRICS_LEAD;
       const gapAfter = nextStart - seg.end;
-      const showNext = showCurrent && hasNext && !inLongGap && gapAfter < GAP_THRESHOLD_SEC;
+      // During the body of a long gap, show no lyric preview. In the final
+      // bubble countdown, the upcoming line is already on stage, so preview
+      // its following line when that passage itself has no long gap.
+      const showNext =
+        showCurrent && hasNext && gapAfter < GAP_THRESHOLD_SEC && (!inLongGap || showCountdown);
 
       if (containerRef.current) containerRef.current.style.display = showCurrent ? "" : "none";
       if (nextContainerRef.current) nextContainerRef.current.style.display = showNext ? "" : "none";
@@ -255,7 +246,23 @@ function LyricsDisplayImpl({
       // Bridged finished lines are past every word's end, so treating them as
       // active keeps the already-sung colors instead of dropping to unsung.
       updateWordSpans(wordRefs.current, seg.words, time, isActive || bridgeShortGap);
+      appliedIdxRef.current = idx;
     };
+
+    applyRef.current = apply;
+
+    const cleanup = () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      if (applyRef.current === apply) {
+        applyRef.current = null;
+        appliedIdxRef.current = null;
+      }
+    };
+
+    // Apply immediately in both timing modes so dependency changes do not
+    // leave visibility stale until the first rAF or transport notification.
+    apply(getCurrentTime());
 
     if (animate) {
       const loop = () => {
@@ -264,29 +271,25 @@ function LyricsDisplayImpl({
         raf = requestAnimationFrame(loop);
       };
       raf = requestAnimationFrame(loop);
-      return () => {
-        cancelled = true;
-        cancelAnimationFrame(raf);
-        cancelAnimationFrame(pendingRaf);
-      };
+      return cleanup;
     }
 
-    apply(getCurrentTime());
     const unsubscribe = subscribe((time) => apply(time));
     return () => {
-      cancelled = true;
-      cancelAnimationFrame(pendingRaf);
+      cleanup();
       unsubscribe();
     };
   }, [segments, subscribe, getCurrentTime, animate]);
 
   // Keep `renderedIdxRef` in sync with the index React has actually committed
-  // to the DOM. It must be updated here (after commit) rather than during
-  // render so an interrupted concurrent render cannot claim an uncommitted
-  // index, which would let the rAF updater mutate visibility against stale DOM.
+  // to the DOM, then apply its visibility before the browser can paint. The
+  // rAF loop remains responsible for the normal per-frame updates.
   useLayoutEffect(() => {
     renderedIdxRef.current = segIdx;
-  }, [segIdx]);
+    if (appliedIdxRef.current !== segIdx) {
+      applyRef.current?.(getCurrentTime());
+    }
+  }, [segIdx, getCurrentTime]);
 
   if (segments.length === 0) {
     return null;

--- a/client/src/components/playback/lyrics-display.tsx
+++ b/client/src/components/playback/lyrics-display.tsx
@@ -202,10 +202,7 @@ function LyricsDisplayImpl({
         setSegIdx(idx);
       }
 
-      // setSegIdx only schedules a re-render; until React commits, the container
-      // refs still render the previous segment. Applying the new index's
-      // visibility to that stale DOM would transiently hide or misplace lines,
-      // so defer per-frame updates until the render has caught up.
+      // Wait for React to render the new segment before mutating its visibility.
       if (idx !== renderedIdxRef.current) {
         return;
       }
@@ -215,10 +212,6 @@ function LyricsDisplayImpl({
 
       const gapBefore = idx === 0 ? seg.start : seg.start - segments[idx - 1].end;
       const timeUntil = seg.start - time;
-      // Circular countdown bubble beside the lyric line for the final seconds
-      // of a long gap. The HUD caption keeps running for the whole gap, so the
-      // bubble is the lyric-side companion countdown while the upcoming lyric
-      // previews.
       const showCountdown =
         gapBefore >= GAP_THRESHOLD_SEC && timeUntil > 0 && timeUntil <= BUBBLE_COUNTDOWN_SEC;
 
@@ -233,9 +226,7 @@ function LyricsDisplayImpl({
 
       const inLongGap = gapBefore >= GAP_THRESHOLD_SEC && timeUntil > LYRICS_LEAD;
       const gapAfter = nextStart - seg.end;
-      // During the body of a long gap, show no lyric preview. In the final
-      // bubble countdown, the upcoming line is already on stage, so preview
-      // its following line when that passage itself has no long gap.
+      // The final countdown may preview a continuous two-line passage.
       const showNext =
         showCurrent && hasNext && gapAfter < GAP_THRESHOLD_SEC && (!inLongGap || showCountdown);
 
@@ -260,8 +251,6 @@ function LyricsDisplayImpl({
       }
     };
 
-    // Apply immediately in both timing modes so dependency changes do not
-    // leave visibility stale until the first rAF or transport notification.
     apply(getCurrentTime());
 
     if (animate) {
@@ -281,9 +270,7 @@ function LyricsDisplayImpl({
     };
   }, [segments, subscribe, getCurrentTime, animate]);
 
-  // Keep `renderedIdxRef` in sync with the index React has actually committed
-  // to the DOM, then apply its visibility before the browser can paint. The
-  // rAF loop remains responsible for the normal per-frame updates.
+  // Synchronize visibility with the committed segment before paint.
   useLayoutEffect(() => {
     renderedIdxRef.current = segIdx;
     if (appliedIdxRef.current !== segIdx) {

--- a/client/src/components/playback/playback-hud.tsx
+++ b/client/src/components/playback/playback-hud.tsx
@@ -315,9 +315,7 @@ function PlaybackHudImpl({ title, artist, config, position = "top" }: PlaybackHu
   const showPixabayCredit = isPixabayTheme(themeIndex);
   const hasTouch = useHasTouchInput();
 
-  // Updates the timer text, skip-button visibility, and the lyric-gap caption
-  // via direct DOM mutation (rAF subscriber), only triggering a text update when
-  // the displayed second changes.
+  // Update playback text without triggering React renders every frame.
   useEffect(() => {
     const updateGapCaption = (time: number) => {
       const el = gapCaptionRef.current;

--- a/client/src/components/playback/playback-hud.tsx
+++ b/client/src/components/playback/playback-hud.tsx
@@ -11,6 +11,7 @@ import {
 import { usePlaybackConfigPersist } from "@/hooks/playback/use-playback-config-persist";
 import type { VideoFlavor } from "@/lib/playback/video-flavor";
 import type { AppConfig } from "@/types/AppConfig";
+import { computeLyricGapCaption, findCurrentSegment } from "@/utils/playback/lyrics-gap";
 import { forwardRef, memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { isPixabayTheme, themeName } from "./background";
 
@@ -299,7 +300,7 @@ function PlaybackHudImpl({ title, artist, config, position = "top" }: PlaybackHu
   const { duration, guideVolume, guideAvailable } = usePlaybackTransportState();
   const { subscribe, getCurrentTime } = usePlaybackTransportActions();
   const { themeIndex, videoFlavor } = usePlaybackThemeState();
-  const { firstSegmentStart, lastSegmentEnd, introSkipLeadSec, transcriptSource } =
+  const { firstSegmentStart, lastSegmentEnd, introSkipLeadSec, segments, transcriptSource } =
     usePlaybackTranscriptState();
   const { handleSkipIntro, handleSkipOutro } = usePlaybackTranscriptActions();
   const { pitchScore, micUserEnabled, micName, micMonitorUserEnabled } = usePlaybackMicState();
@@ -308,16 +309,39 @@ function PlaybackHudImpl({ title, artist, config, position = "top" }: PlaybackHu
   const timerRef = useRef<HTMLParagraphElement>(null);
   const skipIntroRef = useRef<HTMLButtonElement>(null);
   const skipOutroRef = useRef<HTMLButtonElement>(null);
+  const gapCaptionRef = useRef<HTMLParagraphElement>(null);
+  const gapHintRef = useRef(0);
 
   const showPixabayCredit = isPixabayTheme(themeIndex);
   const hasTouch = useHasTouchInput();
 
-  // Updates the timer text and skip-button visibility via direct DOM mutation
-  // (rAF subscriber), only triggering a text update when the displayed second changes.
+  // Updates the timer text, skip-button visibility, and the lyric-gap caption
+  // via direct DOM mutation (rAF subscriber), only triggering a text update when
+  // the displayed second changes.
   useEffect(() => {
+    const updateGapCaption = (time: number) => {
+      const el = gapCaptionRef.current;
+      if (!el) return;
+      if (segments.length === 0) {
+        el.style.display = "none";
+        return;
+      }
+      const idx = findCurrentSegment(segments, time, gapHintRef.current);
+      gapHintRef.current = idx;
+      const caption = computeLyricGapCaption(segments, time, idx);
+      if (caption) {
+        el.textContent = caption;
+        el.style.display = "";
+      } else {
+        el.style.display = "none";
+      }
+    };
+
+    gapHintRef.current = 0;
     if (timerRef.current) {
       timerRef.current.textContent = `${formatTime(getCurrentTime())} / ${formatTime(duration)}`;
     }
+    updateGapCaption(getCurrentTime());
 
     return subscribe((time) => {
       const sec = Math.floor(time);
@@ -335,8 +359,17 @@ function PlaybackHudImpl({ title, artist, config, position = "top" }: PlaybackHu
       if (skipOutroRef.current) {
         skipOutroRef.current.style.display = time > lastSegmentEnd + 1 ? "" : "none";
       }
+      updateGapCaption(time);
     });
-  }, [subscribe, getCurrentTime, duration, firstSegmentStart, introSkipLeadSec, lastSegmentEnd]);
+  }, [
+    subscribe,
+    getCurrentTime,
+    duration,
+    firstSegmentStart,
+    introSkipLeadSec,
+    lastSegmentEnd,
+    segments,
+  ]);
 
   const hudPositionClass =
     position === "bottom"
@@ -366,6 +399,15 @@ function PlaybackHudImpl({ title, artist, config, position = "top" }: PlaybackHu
             <SkipButton ref={skipIntroRef} label="Skip Intro" onClick={handleSkipIntro} />
             <SkipButton ref={skipOutroRef} label="Skip Outro" onClick={handleSkipOutro} />
           </div>
+          <p
+            ref={gapCaptionRef}
+            role="status"
+            aria-live="polite"
+            className={`truncate text-xs font-medium text-white/60 md:text-sm ${
+              position === "bottom" ? "order-first" : ""
+            }`}
+            style={{ display: "none" }}
+          />
         </div>
 
         <div className={`flex min-w-0 items-end ${hudFlowClass}`}>

--- a/client/src/utils/playback/lyrics-gap.ts
+++ b/client/src/utils/playback/lyrics-gap.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared lyric-gap policy for the playback UI.
+ *
+ * A "lyric gap" is a pause of at least `GAP_THRESHOLD_SEC` between the end of
+ * one lyric line and the start of the next. Captions only describe pauses
+ * BETWEEN existing lyric blocks, so an extended instrumental intro before the
+ * first lyric never shows one. During a long gap the HUD renders a small
+ * "Next lyrics in Ns" countdown for the whole gap, then nothing in the final
+ * `CAPTION_HIDE_SEC` so the upcoming lyric preview and its circular bubble can
+ * take over.
+ */
+
+import type { Segment } from "@/types/Transcript";
+
+// Timing offsets: lyrics/words appear slightly before their actual start so the
+// visual transition feels in sync with the audio.
+export const LYRICS_LEAD = 0.15;
+/** Word-level highlight lead used by the lyric word renderer. */
+export const WORD_HIGHLIGHT_LEAD = 0.25;
+/** Grace period after a segment ends before it disappears. */
+export const SEGMENT_LINGER = 0.5;
+/** A gap at or above this many seconds between lyric lines is a real gap. */
+export const GAP_THRESHOLD_SEC = 3.5;
+/** At or below this remaining gap, the caption hides for the lyric preview. */
+export const CAPTION_HIDE_SEC = 3.0;
+
+/**
+ * Finds the segment index that should be displayed at a given `time`.
+ * Uses `hint` (the last known index) to skip already-passed segments.
+ * Prefers the *next* segment when the current time falls in the lead-in window.
+ */
+export function findCurrentSegment(segments: Segment[], time: number, hint: number): number {
+  const start = hint < segments.length && time >= segments[hint].start - LYRICS_LEAD ? hint : 0;
+
+  for (let i = start; i < segments.length; i++) {
+    if (time >= segments[i].end + SEGMENT_LINGER) {
+      const next = i + 1;
+
+      // Through a short pause, keep the finished line current until the next
+      // line's lead-in begins, so the switch happens when the new line starts
+      // rather than when the old one ends.
+      if (
+        next < segments.length &&
+        segments[next].start - segments[i].end < GAP_THRESHOLD_SEC &&
+        time < segments[next].start - LYRICS_LEAD
+      ) {
+        return i;
+      }
+
+      continue;
+    }
+
+    // If we're already in the lead-in of the next segment, jump ahead
+    const next = i + 1;
+    if (next < segments.length && time >= segments[next].start - LYRICS_LEAD) {
+      return next;
+    }
+
+    return i;
+  }
+
+  return Math.max(0, segments.length - 1);
+}
+
+/**
+ * Caption text for the current lyric gap at `time`, or `null` when no caption
+ * applies. `segIdx` must be the index returned by `findCurrentSegment` so the
+ * "current" segment is the upcoming lyric during a long gap (the finished line
+ * is only "current" while it is still active or within its linger, which makes
+ * `timeUntil` non-positive and yields no caption).
+ *
+ * Handles empty segments, the intro before the first lyric (never captioned),
+ * short gaps, the preceding line's active/linger window, and the tail after
+ * the final line.
+ */
+export function computeLyricGapCaption(
+  segments: Segment[],
+  time: number,
+  segIdx: number,
+): string | null {
+  const seg = segments[segIdx];
+  if (!seg) {
+    return null;
+  }
+
+  // Captions only describe pauses between existing lyric blocks: the gap
+  // before the very first lyric is an intro, not a between-block break.
+  if (segIdx === 0) {
+    return null;
+  }
+
+  const gapBefore = seg.start - segments[segIdx - 1].end;
+  const timeUntil = seg.start - time;
+  const inGap = gapBefore >= GAP_THRESHOLD_SEC && timeUntil > LYRICS_LEAD;
+  if (!inGap) {
+    return null;
+  }
+
+  if (timeUntil > CAPTION_HIDE_SEC) {
+    return `Next lyrics in ${Math.ceil(timeUntil)}s`;
+  }
+  return null;
+}

--- a/client/src/utils/playback/lyrics-gap.ts
+++ b/client/src/utils/playback/lyrics-gap.ts
@@ -1,34 +1,13 @@
-/**
- * Shared lyric-gap policy for the playback UI.
- *
- * A "lyric gap" is a pause of at least `GAP_THRESHOLD_SEC` between the end of
- * one lyric line and the start of the next. Captions only describe pauses
- * BETWEEN existing lyric blocks, so an extended instrumental intro before the
- * first lyric never shows one. During a long gap the HUD renders a small
- * "Next lyrics in Ns" countdown for the whole gap, while the lyric-side
- * circular bubble counts down the final `BUBBLE_COUNTDOWN_SEC` beside the
- * upcoming line.
- */
-
 import type { Segment } from "@/types/Transcript";
 
-// Timing offsets: lyrics/words appear slightly before their actual start so the
-// visual transition feels in sync with the audio.
+// Small timing leads keep lyric transitions visually in sync with the audio.
 export const LYRICS_LEAD = 0.15;
-/** Word-level highlight lead used by the lyric word renderer. */
 export const WORD_HIGHLIGHT_LEAD = 0.25;
-/** Grace period after a segment ends before it disappears. */
 export const SEGMENT_LINGER = 0.5;
-/** A gap at or above this many seconds between lyric lines is a real gap. */
 export const GAP_THRESHOLD_SEC = 3.5;
-/** Duration of the circular lyric-side countdown bubble at the end of a long gap. */
 export const BUBBLE_COUNTDOWN_SEC = 3.0;
 
-/**
- * Finds the segment index that should be displayed at a given `time`.
- * Uses `hint` (the last known index) to skip already-passed segments.
- * Prefers the *next* segment when the current time falls in the lead-in window.
- */
+/** Finds the displayed segment, using `hint` to skip already-passed entries. */
 export function findCurrentSegment(segments: Segment[], time: number, hint: number): number {
   const start = hint < segments.length && time >= segments[hint].start - LYRICS_LEAD ? hint : 0;
 
@@ -36,9 +15,7 @@ export function findCurrentSegment(segments: Segment[], time: number, hint: numb
     if (time >= segments[i].end + SEGMENT_LINGER) {
       const next = i + 1;
 
-      // Through a short pause, keep the finished line current until the next
-      // line's lead-in begins, so the switch happens when the new line starts
-      // rather than when the old one ends.
+      // Keep a finished line through short pauses until the next line's lead-in.
       if (
         next < segments.length &&
         segments[next].start - segments[i].end < GAP_THRESHOLD_SEC &&
@@ -50,7 +27,6 @@ export function findCurrentSegment(segments: Segment[], time: number, hint: numb
       continue;
     }
 
-    // If we're already in the lead-in of the next segment, jump ahead
     const next = i + 1;
     if (next < segments.length && time >= segments[next].start - LYRICS_LEAD) {
       return next;
@@ -62,21 +38,6 @@ export function findCurrentSegment(segments: Segment[], time: number, hint: numb
   return Math.max(0, segments.length - 1);
 }
 
-/**
- * Caption text for the current lyric gap at `time`, or `null` when no caption
- * applies. `segIdx` must be the index returned by `findCurrentSegment` so the
- * "current" segment is the upcoming lyric during a long gap (the finished line
- * is only "current" while it is still active or within its linger, which makes
- * `timeUntil` non-positive and yields no caption).
- *
- * Handles empty segments, the intro before the first lyric (never captioned),
- * short gaps, the preceding line's active/linger window, and the tail after
- * the final line. The caption runs for the whole gap and stops the moment the
- * upcoming lyric actually starts (`timeUntil <= 0`); because the text uses
- * `Math.ceil`, it reads `1s` right up to that boundary rather than showing a
- * separate `0s`. The lyric-side bubble counts down the final
- * `BUBBLE_COUNTDOWN_SEC` in parallel.
- */
 export function computeLyricGapCaption(
   segments: Segment[],
   time: number,
@@ -87,17 +48,13 @@ export function computeLyricGapCaption(
     return null;
   }
 
-  // Captions only describe pauses between existing lyric blocks: the gap
-  // before the very first lyric is an intro, not a between-block break.
+  // Intro gaps do not get a HUD caption.
   if (segIdx === 0) {
     return null;
   }
 
   const gapBefore = seg.start - segments[segIdx - 1].end;
   const timeUntil = seg.start - time;
-  // Keep the caption until the lyric actually starts: `Math.ceil` holds the
-  // text at `1s` right up to the zero crossing, and no `0s` is shown once the
-  // lyric is underway.
   const inGap = gapBefore >= GAP_THRESHOLD_SEC && timeUntil > 0;
   if (!inGap) {
     return null;

--- a/client/src/utils/playback/lyrics-gap.ts
+++ b/client/src/utils/playback/lyrics-gap.ts
@@ -5,9 +5,9 @@
  * one lyric line and the start of the next. Captions only describe pauses
  * BETWEEN existing lyric blocks, so an extended instrumental intro before the
  * first lyric never shows one. During a long gap the HUD renders a small
- * "Next lyrics in Ns" countdown for the whole gap, then nothing in the final
- * `CAPTION_HIDE_SEC` so the upcoming lyric preview and its circular bubble can
- * take over.
+ * "Next lyrics in Ns" countdown for the whole gap, while the lyric-side
+ * circular bubble counts down the final `BUBBLE_COUNTDOWN_SEC` beside the
+ * upcoming line.
  */
 
 import type { Segment } from "@/types/Transcript";
@@ -21,8 +21,8 @@ export const WORD_HIGHLIGHT_LEAD = 0.25;
 export const SEGMENT_LINGER = 0.5;
 /** A gap at or above this many seconds between lyric lines is a real gap. */
 export const GAP_THRESHOLD_SEC = 3.5;
-/** At or below this remaining gap, the caption hides for the lyric preview. */
-export const CAPTION_HIDE_SEC = 3.0;
+/** Duration of the circular lyric-side countdown bubble at the end of a long gap. */
+export const BUBBLE_COUNTDOWN_SEC = 3.0;
 
 /**
  * Finds the segment index that should be displayed at a given `time`.
@@ -71,7 +71,11 @@ export function findCurrentSegment(segments: Segment[], time: number, hint: numb
  *
  * Handles empty segments, the intro before the first lyric (never captioned),
  * short gaps, the preceding line's active/linger window, and the tail after
- * the final line.
+ * the final line. The caption runs for the whole gap and stops the moment the
+ * upcoming lyric actually starts (`timeUntil <= 0`); because the text uses
+ * `Math.ceil`, it reads `1s` right up to that boundary rather than showing a
+ * separate `0s`. The lyric-side bubble counts down the final
+ * `BUBBLE_COUNTDOWN_SEC` in parallel.
  */
 export function computeLyricGapCaption(
   segments: Segment[],
@@ -91,13 +95,13 @@ export function computeLyricGapCaption(
 
   const gapBefore = seg.start - segments[segIdx - 1].end;
   const timeUntil = seg.start - time;
-  const inGap = gapBefore >= GAP_THRESHOLD_SEC && timeUntil > LYRICS_LEAD;
+  // Keep the caption until the lyric actually starts: `Math.ceil` holds the
+  // text at `1s` right up to the zero crossing, and no `0s` is shown once the
+  // lyric is underway.
+  const inGap = gapBefore >= GAP_THRESHOLD_SEC && timeUntil > 0;
   if (!inGap) {
     return null;
   }
 
-  if (timeUntil > CAPTION_HIDE_SEC) {
-    return `Next lyrics in ${Math.ceil(timeUntil)}s`;
-  }
-  return null;
+  return `Next lyrics in ${Math.ceil(timeUntil)}s`;
 }

--- a/site/docs/src/lyrics.md
+++ b/site/docs/src/lyrics.md
@@ -103,3 +103,4 @@ During playback, lyrics are displayed with word-by-word highlighting:
 - **Upcoming words** — shown in a dimmer color
 - **Next line** — previewed below the current line
 - **Reading** — for CJK songs, the romanized reading is shown above each token in a smaller weight
+- **Lyric gaps** — during longer pauses between lyric lines, a compact countdown appears beneath the song details while a circular bubble counts down the final three seconds beside the upcoming line. Lines from the next lyric block are not previewed across an instrumental break.


### PR DESCRIPTION
## Summary

Long pauses between lyric blocks now retain a clear countdown without showing a premature lyric preview. Playback stays quiet during an instrumental intro; a compact `Next lyrics in Ns` caption remains beneath the song information for the entire inter-block gap, while the existing lyric-side 3/2/1 bubble appears for the final three seconds.

The upcoming secondary line joins that final countdown when it belongs to the same continuous passage. Segment changes now synchronize direct visibility updates with React's committed lyric content, preventing brief missing or incorrect secondary lines.

This is a narrow playback-UI follow-up only; it does not change lyric timing, alignment, or scoring behavior.

## Validation

- `cd client && pnpm build`
- `cd client && pnpm lint`
- `cd client && pnpm format:check`
- `git diff --check`
- CUDA Docker image rebuilt from this branch and verified to serve `Next lyrics in` with no `Instrumental break` runtime label

## Maintainer approval

The maintainer approved this small, low-risk follow-up directly and confirmed that a separate GitHub Discussion is not needed.