### PR TITLE
fix: make vendor setup re-runs incremental and prevent concurrent runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ below.
 
 ### Fixes
 
+- Re-running setup no longer wipes the vendor folder first: already-installed components are detected and reused, and a second setup trigger is ignored while one is already running.
 - Video files now use audio-stream title metadata, preventing subtitle titles from replacing song names.
 - The lyrics editor now allows re-aligning analyzed songs without requiring a lyrics change.
 - Empty transcription results now finish without attempting forced alignment.

--- a/app-core/src/lib.rs
+++ b/app-core/src/lib.rs
@@ -68,10 +68,10 @@ pub use source::{
     },
 };
 pub use vendor::{
-    SetupFolders, SetupProgress, SetupStep, clear_vendor_dir, is_ready, mark_ready,
-    refresh_analyzer_scripts_if_ready, resolve_data_path_input, run_vendor_setup, step_create_venv,
-    step_download_ffmpeg, step_download_uv, step_extract_scripts, step_install_packages,
-    step_install_python,
+    SetupFolders, SetupProgress, SetupStep, clear_vendor_dir, is_ready, is_setup_running,
+    mark_ready, refresh_analyzer_scripts_if_ready, resolve_data_path_input, run_vendor_setup,
+    step_create_venv, step_download_ffmpeg, step_download_uv, step_extract_scripts,
+    step_install_packages, step_install_python,
 };
 
 pub fn startup() -> Result<(), String> {

--- a/app-core/src/vendor.rs
+++ b/app-core/src/vendor.rs
@@ -622,11 +622,12 @@ fn detect_gpu() -> GpuInfo {
                 legacy_torch: true,
             };
         }
-        return GpuInfo {
+        info!("[vendor] GPU detection: Apple Silicon (MPS)");
+        GpuInfo {
             device: "mps",
             torch_index: "https://download.pytorch.org/whl/cpu",
             legacy_torch: false,
-        };
+        }
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/app-core/src/vendor.rs
+++ b/app-core/src/vendor.rs
@@ -1,6 +1,7 @@
 use std::{
     path::{Path, PathBuf},
     process::Command,
+    sync::atomic::{AtomicBool, Ordering},
 };
 
 use serde::{Deserialize, Serialize};
@@ -54,6 +55,19 @@ pub fn clear_vendor_dir() -> Result<(), String> {
             .map_err(|e| format!("Failed to clear vendor directory: {e}"))?;
     }
     Ok(())
+}
+
+/// Remove staging dirs left behind by interrupted downloads. Each setup step
+/// already skips work that is present on disk, so a re-run only needs these
+/// leftovers gone — wiping the whole vendor folder would discard a fully
+/// installed setup and force every component to be downloaded again.
+fn cleanup_vendor_staging(vendor: &Path) {
+    for name in ["_tmp_ffmpeg", "_tmp_uv"] {
+        let dir = vendor.join(name);
+        if dir.is_dir() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
 }
 
 pub(crate) fn ffmpeg_path() -> PathBuf {
@@ -143,7 +157,32 @@ fn migrate_cache_data_to_targets(targets: &CachePaths) -> Result<(), String> {
     Ok(())
 }
 
+static SETUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Returns `true` while a vendor setup run is executing in this process.
+pub fn is_setup_running() -> bool {
+    SETUP_IN_PROGRESS.load(Ordering::SeqCst)
+}
+
 pub fn run_vendor_setup(
+    folders: SetupFolders,
+    on_progress: impl FnMut(SetupProgress) + Send,
+    on_data_migrated: impl FnMut(&Path) -> Result<(), String>,
+) -> Result<(), String> {
+    if !try_begin_setup() {
+        return Err("Setup is already running".to_string());
+    }
+
+    let result = run_vendor_setup_inner(folders, on_progress, on_data_migrated);
+    SETUP_IN_PROGRESS.store(false, Ordering::SeqCst);
+    result
+}
+
+fn try_begin_setup() -> bool {
+    !SETUP_IN_PROGRESS.swap(true, Ordering::SeqCst)
+}
+
+fn run_vendor_setup_inner(
     folders: SetupFolders,
     mut on_progress: impl FnMut(SetupProgress) + Send,
     mut on_data_migrated: impl FnMut(&Path) -> Result<(), String>,
@@ -213,9 +252,9 @@ pub fn run_vendor_setup(
         emit(
             SetupStep::ClearVendor,
             14,
-            "Clearing vendor folder...".to_string(),
+            "Cleaning up vendor folder...".to_string(),
         );
-        clear_vendor_dir()?;
+        cleanup_vendor_staging(&vendor_dir());
     }
 
     emit(SetupStep::Ffmpeg, 24, "Downloading ffmpeg...".to_string());
@@ -792,4 +831,67 @@ pub fn refresh_analyzer_scripts_if_ready() -> Result<(), String> {
 
 pub fn mark_ready() -> Result<(), String> {
     std::fs::write(ready_marker(), "ok").map_err(|e| format!("Failed to mark ready: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    use super::*;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, AtomicOrdering::SeqCst);
+        std::env::temp_dir().join(format!(
+            "nightingale_{}_{}_{}",
+            name,
+            std::process::id(),
+            id
+        ))
+    }
+
+    #[test]
+    fn cleanup_removes_staging_dirs_and_keeps_installed_files() {
+        let vendor = unique_temp_dir("staging");
+        let ffmpeg_tmp = vendor.join("_tmp_ffmpeg");
+        let uv_tmp = vendor.join("_tmp_uv");
+        std::fs::create_dir_all(&ffmpeg_tmp).expect("create _tmp_ffmpeg");
+        std::fs::create_dir_all(&uv_tmp).expect("create _tmp_uv");
+        let installed = vendor.join("venv");
+        std::fs::create_dir_all(&installed).expect("create venv dir");
+        std::fs::write(vendor.join("ffmpeg"), "binary").expect("write fake ffmpeg");
+
+        cleanup_vendor_staging(&vendor);
+
+        assert!(!ffmpeg_tmp.exists());
+        assert!(!uv_tmp.exists());
+        assert!(installed.is_dir());
+        assert!(vendor.join("ffmpeg").is_file());
+
+        std::fs::remove_dir_all(&vendor).expect("clean up temp vendor dir");
+    }
+
+    #[test]
+    fn cleanup_is_noop_for_missing_dirs() {
+        let vendor = unique_temp_dir("staging_missing");
+        std::fs::create_dir_all(&vendor).expect("create temp vendor dir");
+        cleanup_vendor_staging(&vendor);
+        assert!(vendor.is_dir());
+        std::fs::remove_dir_all(&vendor).expect("clean up temp vendor dir");
+    }
+
+    #[test]
+    fn setup_lock_is_exclusive_until_released() {
+        assert!(!is_setup_running());
+        assert!(try_begin_setup());
+        assert!(is_setup_running());
+        assert!(
+            !try_begin_setup(),
+            "second concurrent setup must be refused"
+        );
+        SETUP_IN_PROGRESS.store(false, AtomicOrdering::SeqCst);
+        assert!(!is_setup_running());
+        assert!(try_begin_setup(), "lock must be reacquirable after release");
+        SETUP_IN_PROGRESS.store(false, AtomicOrdering::SeqCst);
+    }
 }

--- a/client/src-server/src/commands/vendor.rs
+++ b/client/src-server/src/commands/vendor.rs
@@ -27,6 +27,13 @@ pub(crate) fn trigger_setup(events: Arc<EventBus>, payload: Value) -> CmdResult 
             .map_err(|e| ApiError::bad_request(format!("invalid trigger_setup args: {e}")))?
     };
 
+    // A setup run may already be in flight (e.g. started before a page
+    // refresh). Ignore the extra trigger instead of racing it — the running
+    // setup keeps emitting progress events for the UI.
+    if app_core::is_setup_running() {
+        return Ok(Value::Null);
+    }
+
     let events_clone = events.clone();
     std::thread::spawn(move || {
         let events_for_progress = events_clone.clone();

--- a/client/src-tauri/src/vendor.rs
+++ b/client/src-tauri/src/vendor.rs
@@ -7,6 +7,13 @@ pub(crate) fn trigger_setup(
     data_path: Option<String>,
     cache_paths: Option<CachePaths>,
 ) {
+    // A setup run may already be in flight (e.g. started before a page
+    // refresh). Ignore the extra trigger instead of racing it — the running
+    // setup keeps emitting progress events for the UI.
+    if app_core::is_setup_running() {
+        return;
+    }
+
     std::thread::spawn(move || {
         if let Some(paths) = cache_paths.as_ref() {
             for path in [&paths.songs, &paths.videos, &paths.models, &paths.vendor]


### PR DESCRIPTION
## Problem

`run_vendor_setup` unconditionally deletes the entire vendor folder before re-running the setup steps. Every step already has an "exists → skip" check (ffmpeg, uv, python, venv, and `uv pip install` is incremental), but the wipe defeats all of them — so any setup re-trigger re-downloads ffmpeg, uv, Python, the venv, and all packages from scratch.

There is also no concurrency guard: `trigger_setup` spawns a fresh thread on every call with no lock. While a long step runs (e.g. dependency install), the setup dialog can sit on the welcome step after a page refresh; clicking "Continue" then starts a second run that deletes the vendor folder **out from under the running setup**. Exiting mid-setup has a similar effect: no `.ready` marker means the next launch starts over from a full wipe.

## The change

- Replace the unconditional `clear_vendor_dir()` with a cleanup that only removes the `_tmp_ffmpeg` / `_tmp_uv` staging dirs left behind by interrupted downloads. Completed installs are detected and reused, so a re-run is fast and non-destructive. (The wipe before a data-folder migration is kept — that path intentionally starts fresh.)
- Guard the run with a process-wide `SETUP_IN_PROGRESS` flag and expose `is_setup_running()`.
- The Tauri and server `trigger_setup` commands ignore extra triggers while a setup is already running instead of racing it; the running setup keeps emitting progress events, so the UI picks the run back up at the next step boundary.

## Testing

- New unit tests: `cleanup_removes_staging_dirs_and_keeps_installed_files`, `cleanup_is_noop_for_missing_dirs`, `setup_lock_is_exclusive_until_released`.
- `cargo test -p app-core --lib`: 39 passed, 0 failed.
- `cargo clippy --workspace --all-targets --all-features --locked` and `cargo fmt --all --check` clean.
- CHANGELOG updated under Unreleased → Fixes.

## Note on the second commit

`detect_gpu`'s macOS tail used a redundant `return`, which fails `clippy::needless_return` whenever the macOS cfg block is compiled in (Linux CI never compiles it, so the failure is invisible to CI). I included the one-line fix as a separate commit so the lint gate passes locally on macOS while testing this change — happy to drop it if you'd rather take it through its own PR.