### PR TITLE
Discussion #106: add multi-level song sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ below.
 - Playback settings now have a dedicated tab with a proportional live preview, lyric placement controls, and 50–250% lyric and pitch-graph scaling (100% by default).
 - Add bulk song actions and a Refresh Metadata action for reloading metadata from the library source.
 - Queued or in-progress song analysis can now be cancelled per song or in bulk across filtered songs.
-- Added compact sortable song-table headers with stable duplicate-file rendering and flicker-free transitions.
+- Added compact sortable song-table headers with persisted multi-level priorities, immediate list reordering, displayed-duration tie-breaking, and stable duplicate-file rendering.
 
 ### Improvements
 

--- a/app-core/src/config.rs
+++ b/app-core/src/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use ts_rs::TS;
 
 use crate::secret;
@@ -209,12 +209,32 @@ pub struct AppConfig {
     pub vocal_detection_threshold_pct: Option<f64>,
     pub auto_analyze: Option<bool>,
     pub song_list_view: Option<String>,
-    pub song_list_sort: Option<SongSort>,
+    #[serde(default, deserialize_with = "deserialize_song_list_sort")]
+    pub song_list_sort: Option<Vec<SongSort>>,
     pub language_overrides: Option<HashMap<String, String>>,
 }
 
 fn default_data_path_option() -> Option<PathBuf> {
     Some(AppConfig::default_data_path())
+}
+
+fn deserialize_song_list_sort<'de, D>(deserializer: D) -> Result<Option<Vec<SongSort>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum PersistedSongSort {
+        One(SongSort),
+        Many(Vec<SongSort>),
+    }
+
+    Ok(
+        Option::<PersistedSongSort>::deserialize(deserializer)?.map(|sort| match sort {
+            PersistedSongSort::One(sort) => vec![sort],
+            PersistedSongSort::Many(sorts) => sorts,
+        }),
+    )
 }
 
 impl Default for AppConfig {

--- a/app-core/src/library_db/queries.rs
+++ b/app-core/src/library_db/queries.rs
@@ -234,17 +234,19 @@ fn build_song_where_clause(
     }
 }
 
-fn song_order(sort: Option<SongSort>) -> Option<String> {
-    let sort = sort?;
-    let direction = match sort.direction {
+fn sort_direction(direction: SortDirection) -> &'static str {
+    match direction {
         SortDirection::Ascending => "ASC",
         SortDirection::Descending => "DESC",
-    };
-    let expression = match sort.column {
+    }
+}
+
+fn sort_expression(column: SongSortColumn) -> &'static str {
+    match column {
         SongSortColumn::Title => "s.title COLLATE NOCASE",
         SongSortColumn::Artist => "s.artist COLLATE NOCASE",
         SongSortColumn::Album => "s.album COLLATE NOCASE",
-        SongSortColumn::Duration => "s.duration_secs",
+        SongSortColumn::Duration => "CAST(s.duration_secs AS INTEGER)",
         SongSortColumn::Status => {
             "CASE WHEN EXISTS (SELECT 1 FROM analysis_queue aq WHERE aq.file_hash = s.file_hash AND aq.status = 'analyzing') THEN 0 \
              WHEN EXISTS (SELECT 1 FROM analysis_queue aq WHERE aq.file_hash = s.file_hash AND aq.status = 'failed') THEN 1 \
@@ -252,9 +254,24 @@ fn song_order(sort: Option<SongSort>) -> Option<String> {
              WHEN EXISTS (SELECT 1 FROM analysis_queue aq WHERE aq.file_hash = s.file_hash AND aq.status = 'queued') THEN 3 \
              ELSE 4 END"
         }
-    };
+    }
+}
 
-    Some(format!("{expression} {direction}, s.id {direction}"))
+fn song_order(sorts: &[SongSort]) -> Option<String> {
+    let last_sort = sorts.last()?;
+    let mut clauses = sorts
+        .iter()
+        .map(|sort| {
+            format!(
+                "{} {}",
+                sort_expression(sort.column),
+                sort_direction(sort.direction)
+            )
+        })
+        .collect::<Vec<_>>();
+    clauses.push(format!("s.id {}", sort_direction(last_sort.direction)));
+
+    Some(clauses.join(", "))
 }
 
 pub(crate) fn load_songs_page(params: &LoadSongsParams) -> rusqlite::Result<SongsStore> {
@@ -285,7 +302,7 @@ pub(crate) fn load_songs_page(params: &LoadSongsParams) -> rusqlite::Result<Song
     } else {
         ""
     };
-    let requested_order = song_order(params.sort);
+    let requested_order = params.sort.as_deref().and_then(song_order);
     let default_filtered_order =
         format!("{queue_order}{playlist_order}s.artist COLLATE NOCASE, s.title COLLATE NOCASE");
     let filtered_order = requested_order

--- a/app-core/src/library_model.rs
+++ b/app-core/src/library_model.rs
@@ -58,7 +58,7 @@ pub struct LoadSongsParams {
     pub search: Option<String>,
     pub filters: LibraryMenuFilters,
     #[serde(default)]
-    pub sort: Option<SongSort>,
+    pub sort: Option<Vec<SongSort>>,
     pub skip: usize,
     pub take: usize,
 }

--- a/client/src/bridge/schemas.ts
+++ b/client/src/bridge/schemas.ts
@@ -78,10 +78,12 @@ export const appConfigSchema: z.ZodType<AppConfig> = z.object({
   auto_analyze: nullableBoolean,
   song_list_view: nullableString,
   song_list_sort: z
-    .object({
-      column: z.enum(['title', 'artist', 'album', 'duration', 'status']),
-      direction: z.enum(['ascending', 'descending']),
-    })
+    .array(
+      z.object({
+        column: z.enum(['title', 'artist', 'album', 'duration', 'status']),
+        direction: z.enum(['ascending', 'descending']),
+      }),
+    )
     .nullable(),
   language_overrides: z.record(z.string(), z.string()).nullable(),
 });

--- a/client/src/features/library/components/song-list/song-list.tsx
+++ b/client/src/features/library/components/song-list/song-list.tsx
@@ -31,7 +31,7 @@ import { SongTable } from './views/song-table';
 type SongCollectionProps = {
   songs: Song[];
   view: SongListView;
-  sort: SongSort | null;
+  sort: readonly SongSort[];
   sortingDisabled: boolean;
   loading: boolean;
   hasActiveFilter: boolean;
@@ -44,17 +44,22 @@ type SongCollectionProps = {
 const hasFilters = (values: readonly unknown[]): boolean =>
   values.some((value) => (typeof value === 'string' ? value.trim() !== '' : Boolean(value)));
 
-const songListSort = (config: AppConfig | undefined): SongSort | null =>
-  config?.song_list_sort ?? null;
+const songListSort = (config: AppConfig | undefined): readonly SongSort[] =>
+  config?.song_list_sort ?? [];
 
-const nextSongSort = (sort: SongSort | null, column: SongSortColumn): SongSort | null => {
-  if (sort?.column !== column) {
-    return { column, direction: 'ascending' };
+const nextSongSort = (sorts: readonly SongSort[], column: SongSortColumn): SongSort[] | null => {
+  const sortIndex = sorts.findIndex((sort) => sort.column === column);
+  if (sortIndex === -1) {
+    return [...sorts, { column, direction: 'ascending' }];
   }
-  if (sort.direction === 'ascending') {
-    return { column, direction: 'descending' };
+  if (sorts[sortIndex].direction === 'ascending') {
+    return sorts.map((sort, index) =>
+      index === sortIndex ? { ...sort, direction: 'descending' } : sort,
+    );
   }
-  return null;
+
+  const nextSorts = sorts.filter((_, index) => index !== sortIndex);
+  return nextSorts.length === 0 ? null : nextSorts;
 };
 
 const EmptySongs = ({ filtered }: { filtered: boolean }) => (

--- a/client/src/features/library/components/song-list/views/song-table.tsx
+++ b/client/src/features/library/components/song-list/views/song-table.tsx
@@ -13,7 +13,7 @@ import { SongTableRow } from './song-table-row';
 
 type SongTableProps = {
   songs: Song[];
-  sort: SongSort | null;
+  sort: readonly SongSort[];
   sortingDisabled: boolean;
   onSort: (column: SongSortColumn) => void;
   getItemProps: (song: Song, index: number) => SongItemProps;
@@ -21,7 +21,7 @@ type SongTableProps = {
 
 type SongTableHeaderProps = {
   column: SongColumn;
-  sort: SongSort | null;
+  sort: readonly SongSort[];
   sortingDisabled: boolean;
   onSort: (column: SongSortColumn) => void;
 };
@@ -32,8 +32,9 @@ const SongTableHeader = ({ column, sort, sortingDisabled, onSort }: SongTableHea
     return <th className={column.thClassName}>{column.header}</th>;
   }
 
-  const activeDirection = sortColumn === sort?.column ? sort.direction : undefined;
-  const ariaSort = activeDirection ?? 'none';
+  const sortIndex = sort.findIndex(({ column: sortedColumn }) => sortedColumn === sortColumn);
+  const activeDirection = sortIndex === -1 ? undefined : sort[sortIndex].direction;
+  const priority = sortIndex + 1;
   let icon = (
     <ArrowUpDownIcon className="size-3 shrink-0 translate-y-px opacity-40" aria-hidden="true" />
   );
@@ -44,7 +45,7 @@ const SongTableHeader = ({ column, sort, sortingDisabled, onSort }: SongTableHea
   }
 
   return (
-    <th className={column.thClassName} aria-sort={ariaSort}>
+    <th className={column.thClassName} aria-sort={sortIndex === 0 ? activeDirection : undefined}>
       <button
         type="button"
         disabled={sortingDisabled}
@@ -55,7 +56,17 @@ const SongTableHeader = ({ column, sort, sortingDisabled, onSort }: SongTableHea
         onClick={() => onSort(sortColumn)}
       >
         {column.header}
-        {icon}
+        <span className="inline-flex items-start" aria-hidden="true">
+          {icon}
+          {activeDirection && (
+            <sup className="-ml-0.5 text-[0.45rem] leading-none tabular-nums">{priority}</sup>
+          )}
+        </span>
+        {activeDirection && (
+          <span className="sr-only">
+            , sorted {activeDirection}, priority {priority}
+          </span>
+        )}
       </button>
     </th>
   );

--- a/client/src/features/library/queries/use-songs.ts
+++ b/client/src/features/library/queries/use-songs.ts
@@ -43,21 +43,10 @@ export const useSongs = () => {
   const { data: config } = useConfig();
   const { search } = useSearch();
   const { artist, album, playlist, query, status, transcript_source } = useLibraryFilter();
-  const sort = config?.song_list_sort ?? null;
+  const sort = config?.song_list_sort ?? [];
 
   return useInfiniteQuery({
-    queryKey: [
-      ...SONGS,
-      search,
-      artist,
-      album,
-      playlist,
-      query,
-      status,
-      transcript_source,
-      sort?.column,
-      sort?.direction,
-    ],
+    queryKey: [...SONGS, search, artist, album, playlist, query, status, transcript_source, sort],
     queryFn: ({ pageParam = 0 }: { pageParam?: number }) => {
       const params: LoadSongsParams = {
         search: search || null,
@@ -70,7 +59,7 @@ export const useSongs = () => {
           transcript_source: transcript_source ?? null,
           search: null,
         },
-        sort,
+        sort: sort.length === 0 ? null : sort,
         skip: pageParam,
         take: PAGE_SIZE,
       };
@@ -80,7 +69,6 @@ export const useSongs = () => {
       const loaded = allPages.reduce((sum, page) => sum + page.processed.length, 0);
       return loaded < lastPage.processed_count ? loaded : undefined;
     },
-    keepPreviousData: true,
   });
 };
 

--- a/client/src/types/AppConfig.ts
+++ b/client/src/types/AppConfig.ts
@@ -41,6 +41,6 @@ export type AppConfig = {
   vocal_detection_threshold_pct: number | null;
   auto_analyze: boolean | null;
   song_list_view: string | null;
-  song_list_sort: SongSort | null;
+  song_list_sort: SongSort[] | null;
   language_overrides: { [key in string]: string } | null;
 };

--- a/client/src/types/LoadSongsParams.ts
+++ b/client/src/types/LoadSongsParams.ts
@@ -5,7 +5,7 @@ import type { SongSort } from "./SongSort";
 export type LoadSongsParams = {
   search: string | null;
   filters: LibraryMenuFilters;
-  sort: SongSort | null;
+  sort: SongSort[] | null;
   skip: number;
   take: number;
 };


### PR DESCRIPTION
Pull request summary
Song headers now support ordered, persistent multi-level sorting.
- Clicking an unsorted column adds it as the next ascending priority.
- Clicking it again changes that priority to descending.
- Clicking it a third time removes it.
- Removing a priority automatically renumbers all subsequent priorities.
- Changing direction does not change priority.
- To move a column to another priority, remove it and add it again.
- The entire sequence persists across application restarts.
- Existing single-column settings are migrated automatically.
- Superscript numbers beside the arrows show each column’s priority.
- Duration sorting uses the displayed whole-second value, allowing the next priority to resolve visible duration ties.
Example:
1. Artist ↑
2. Album ↑
3. Duration ↓
Songs are first grouped alphabetically by artist. Songs with the same artist are then ordered by album. Only songs with the same artist and album are ordered by descending duration.
If Album is removed, Duration becomes priority 2:
1. Artist ↑
2. Duration ↓
For another example:
1. Artist ↓
2. Duration ↓
3. Song ↑
Within the same artist, longer songs appear first. If two songs both display 3:11, Song sorts that visible tie alphabetically.